### PR TITLE
Added gestureState dx check to shouldSetPanResponder method

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,8 +40,8 @@ class GestureRecognizer extends Component {
     });
   }
 
-  _handleShouldSetPanResponder(evt) {
-    return evt.nativeEvent.touches.length === 1;
+  _handleShouldSetPanResponder(evt, gestureState) {
+    return evt.nativeEvent.touches.length === 1 && Math.abs(gestureState.dx) > 5;
   }
 
   _handlePanResponderEnd(evt, gestureState) {


### PR DESCRIPTION
I added gestureState dx check when setting PanResponder. This fixes the touch blocking issue https://github.com/glepur/react-native-swipe-gestures/issues/1 

Inspiration and solution pretty much from this https://github.com/facebook/react-native/issues/3082