### PR TITLE
Add onSwipeMove prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ class SomeComponent extends Component {
     this.setState({myText: 'You swiped right!'});
   }
 
+  onSwipeMove(gestureState) {
+    console.log(gestureState);
+  }
+
   onSwipe(gestureName, gestureState) {
     const {SWIPE_UP, SWIPE_DOWN, SWIPE_LEFT, SWIPE_RIGHT} = swipeDirections;
     this.setState({gestureName: gestureName});
@@ -62,7 +66,7 @@ class SomeComponent extends Component {
   }
 
   render() {
-    
+
     const config = {
       velocityThreshold: 0.3,
       directionalOffsetThreshold: 80
@@ -71,6 +75,7 @@ class SomeComponent extends Component {
     return (
       <GestureRecognizer
         onSwipe={(direction, state) => this.onSwipe(direction, state)}
+        onSwipeMove={(state) => this.onSwipeMove(state)}
         onSwipeUp={(state) => this.onSwipeUp(state)}
         onSwipeDown={(state) => this.onSwipeDown(state)}
         onSwipeLeft={(state) => this.onSwipeLeft(state)}
@@ -107,6 +112,12 @@ Can be passed within optional `config` property.
 | Params        | Type          | Description  |
 | ------------- |:-------------:| ------------ |
 | gestureName   | String        | Name of the gesture (look example above) |
+| gestureState  | Object        | gestureState received from PanResponder  |
+
+#### onSwipeMove(gestureState)
+
+| Params        | Type          | Description  |
+| ------------- |:-------------:| ------------ |
 | gestureState  | Object        | gestureState received from PanResponder  |
 
 

--- a/index.js
+++ b/index.js
@@ -32,10 +32,12 @@ class GestureRecognizer extends Component {
 
   componentWillMount() {
     const responderEnd = this._handlePanResponderEnd.bind(this);
+    const responderMove = this._handlePanResponderMove.bind(this);
     const shouldSetResponder = this._handleShouldSetPanResponder.bind(this);
     this._panResponder = PanResponder.create({ //stop JS beautify collapse
       onStartShouldSetPanResponder: shouldSetResponder,
       onMoveShouldSetPanResponder: shouldSetResponder,
+      onPanResponderMove: responderMove,
       onPanResponderRelease: responderEnd,
       onPanResponderTerminate: responderEnd
     });
@@ -44,7 +46,6 @@ class GestureRecognizer extends Component {
   _handleShouldSetPanResponder(evt, gestureState) {
     return evt.nativeEvent.touches.length === 1 && !this._gestureIsClick(gestureState);
   }
-  
   _gestureIsClick(gestureState) {
     return Math.abs(gestureState.dx) < 5  && Math.abs(gestureState.dy) < 5;
   }
@@ -52,6 +53,15 @@ class GestureRecognizer extends Component {
   _handlePanResponderEnd(evt, gestureState) {
     const swipeDirection = this._getSwipeDirection(gestureState);
     this._triggerSwipeHandlers(swipeDirection, gestureState);
+  }
+
+  _handlePanResponderMove(evt, gestureState) {
+    this._triggerMove(gestureState);
+  }
+
+  _triggerMove(gestureState){
+    const onSwipeMove = this.props.onSwipeMove;
+    onSwipeMove && onSwipeMove(gestureState);
   }
 
   _triggerSwipeHandlers(swipeDirection, gestureState) {


### PR DESCRIPTION
Hey,

React native `PanResponder` has another property called `onPanResponderMove`, I had to animate a component relative to the amount of movement of a swipe. So I implemented it.

I think it won't be creating any conflict with the current usage case. I also updated the readme & example.

Thank you.