### PR TITLE
fix(_gestureIsClick): configurable threshold for high dpi screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Can be passed within optional `config` property.
 | -------------------------- |:-------------:| ------- | ------------ |
 | velocityThreshold          | Number        | 0.3     | Velocity that has to be breached in order for swipe to be triggered (`vx` and `vy` peroperties of `gestureState`) |
 | directionalOffsetThreshold | Number        | 80      | Absolute offset that shouldn't be breached for swipe to be triggered (`dy` for horizontal swipe, `dx` for vertical swipe) |
+| gestureIsClickThreshold    | Number        | 5       | Absolute distance that should be breached for the gesture to not be considered a click (`dx` or `dy` peroperties of `gestureState`) |
 
 ## Methods
 

--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ Can be passed within optional `config` property.
 
 | Params                     | Type          | Default | Description  |
 | -------------------------- |:-------------:| ------- | ------------ |
-| velocityThreshold          | Number        | 0.3     | Velocity that has to be breached in order for swipe to be triggered (`vx` and `vy` peroperties of `gestureState`) |
+| velocityThreshold          | Number        | 0.3     | Velocity that has to be breached in order for swipe to be triggered (`vx` and `vy` properties of `gestureState`) |
 | directionalOffsetThreshold | Number        | 80      | Absolute offset that shouldn't be breached for swipe to be triggered (`dy` for horizontal swipe, `dx` for vertical swipe) |
-| gestureIsClickThreshold    | Number        | 5       | Absolute distance that should be breached for the gesture to not be considered a click (`dx` or `dy` peroperties of `gestureState`) |
+| gestureIsClickThreshold    | Number        | 5       | Absolute distance that should be breached for the gesture to not be considered a click (`dx` or `dy` properties of `gestureState`) |
 
 ## Methods
 

--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ export const swipeDirections = {
 
 const swipeConfig = {
   velocityThreshold: 0.3,
-  directionalOffsetThreshold: 80
+  directionalOffsetThreshold: 80,
+  gestureIsClickThreshold: 5
 };
 
 function isValidSwipe(velocity, velocityThreshold, directionalOffset, directionalOffsetThreshold) {
@@ -46,7 +47,8 @@ class GestureRecognizer extends Component {
   }
   
   _gestureIsClick(gestureState) {
-    return Math.abs(gestureState.dx) < 5  && Math.abs(gestureState.dy) < 5;
+    return Math.abs(gestureState.dx) < swipeConfig.gestureIsClickThreshold
+      && Math.abs(gestureState.dy) < swipeConfig.gestureIsClickThreshold;
   }
 
   _handlePanResponderEnd(evt, gestureState) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-swipe-gestures",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "4-directional swipe gestures for react-native",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Screens with a high dpi have the issue that clicks are not registered.